### PR TITLE
Fixed example to properly work

### DIFF
--- a/Resources/doc/serialization-groups-and-relations.md
+++ b/Resources/doc/serialization-groups-and-relations.md
@@ -148,7 +148,7 @@ services:
         calls:
             -       method:    "initDenormalizationContext"
                     arguments:
-                        -      { groups: [ "offer" ] }
+                        -      [ { groups: [ "offer" ] } }
         tags:       [ { name: "api.resource" } ]
 ```
 


### PR DESCRIPTION
The groups missing an array, which results in a non-working deserializer.
